### PR TITLE
Support loading a combined JSON file

### DIFF
--- a/json2capella/datatypes.py
+++ b/json2capella/datatypes.py
@@ -64,3 +64,8 @@ class StructAttrs(_BaseModel):
     multiplicity: t.Annotated[
         str | None, p.Field(pattern=r"^(?:\d+\.\.)?(\d+|\*)$")
     ] = None
+
+
+CombinedModel: t.TypeAlias = dict[str, Package]
+JSONFileContents: t.TypeAlias = Package | CombinedModel
+JSONAdapter: p.TypeAdapter[JSONFileContents] = p.TypeAdapter(JSONFileContents)

--- a/json2capella/importer.py
+++ b/json2capella/importer.py
@@ -35,7 +35,20 @@ def load_json(json_path: pathlib.Path) -> datatypes.Package:
                 ],
             }
         )
-    return datatypes.Package.model_validate(json.loads(json_path.read_text()))
+
+    data = datatypes.JSONAdapter.validate_json(json_path.read_text())
+    if isinstance(data, datatypes.Package):
+        return data
+    if isinstance(data, dict):
+        assert all(isinstance(i, datatypes.Package) for i in data.values())
+        return datatypes.Package.model_validate(
+            {
+                "name": "JSON root package",
+                "prefix": "json_root_package",
+                "subPackages": list(data.values()),
+            }
+        )
+    raise AssertionError(f"Unhandled data type in JSON: {type(data)!r}")
 
 
 def get_old_by_id(old_jsons: list[T], int_id: int | None) -> T | None:


### PR DESCRIPTION
In addition to loading a set of packages from a directory of JSON files, also support loading such a set from a combined JSON file. This combined file is expected to contain a top-level JSON dictionary which maps the filename (without `.json` suffix) to the dictionary that would otherwise be contained in that file.